### PR TITLE
Remove unused import from main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from config import config
 from massist.logger import init_logging
-from massist.redis import AsyncRedisPoolContext, get_redis_pool, init_redis
+from massist.redis import AsyncRedisPoolContext, init_redis
 from massist.router import router
 
 ALLOW_ORIGINS = config.ALLOW_ORIGINS


### PR DESCRIPTION
Eliminate the unnecessary `get_redis_pool` import from `massist.redis` in `main.py`.