### PR TITLE
feat(team): conditionally enable TelegramTools and log session details

### DIFF
--- a/massist/meta.py
+++ b/massist/meta.py
@@ -26,7 +26,7 @@ class Meta(BaseModel):
 
     instructions: List[str] = Field(
         default_factory=lambda: [
-            # "0. You must only respond in Russian",
+            "0. You must only respond in Russian",
             "1. Knowledge Base Search:",
             "   - Always start by searching the knowledge base using search_knowledge_base tool",
             "   - Analyze ALL returned documents thoroughly before responding",

--- a/massist/team.py
+++ b/massist/team.py
@@ -26,15 +26,25 @@ def get_mitigator_team(user_id: str, session_id: str, model: Model) -> Team:
     # Setup tools list based on configuration
     tools: List[Any] = [
         DuckDuckGoTools(),
-        TelegramTools(chat_id=config.TGBOT_CHAT_ID, token=config.TGBOT_API_TOKEN),
     ]
+
+    # Add TelegramTools only if both required config variables are present
+    if config.TGBOT_CHAT_ID and config.TGBOT_API_TOKEN:
+        tools.append(
+            TelegramTools(chat_id=config.TGBOT_CHAT_ID, token=config.TGBOT_API_TOKEN)
+        )
+        logger.info(
+            f"TelegramTools enabled [session_id={session_id}, user_id={user_id}]"
+        )
 
     # Add ThinkingTools only if enabled in config
     if config.THINKING_TOOLS_ENABLE:
         tools.append(
             ThinkingTools(add_instructions=config.THINKING_TOOLS_ADD_INSTRUCTIONS)
         )
-        logger.info("ThinkingTools enabled")
+        logger.info(
+            f"ThinkingTools enabled [session_id={session_id}, user_id={user_id}]"
+        )
 
     return Team(
         name="Mitigator AI Assistant",


### PR DESCRIPTION
- Added conditional check to include TelegramTools only if both TGBOT_CHAT_ID and TGBOT_API_TOKEN are present in the configuration.
- Enhanced logging to include session_id and user_id when TelegramTools and ThinkingTools are enabled.