### PR TITLE
feat: Update agent and team modules for improved functionality

### DIFF
--- a/massist/agent.py
+++ b/massist/agent.py
@@ -29,8 +29,6 @@ def get_agent(
     agent_id: str, topic: str, params: AgentParams, tools: List[Any] | None = None
 ):
     meta = Meta(agent_id=agent_id, topic=topic)
-    # FIXME: remove default stolyarchuk
-
     if tools is None:
         tools = [
             DuckDuckGoTools(),

--- a/massist/team.py
+++ b/massist/team.py
@@ -8,7 +8,7 @@ from agno.tools.telegram import TelegramTools
 from agno.tools.thinking import ThinkingTools
 
 from config import config
-from massist.agent import AgentParams, get_agent, get_image_agent, get_search_agent
+from massist.agent import AgentParams, get_agent, get_search_agent
 from massist.logger import get_logger
 from massist.models import get_gemini_pri_model, get_gemini_sec_model
 from massist.storage import get_storage
@@ -55,7 +55,7 @@ def get_mitigator_team(user_id: str, session_id: str, model: Model) -> Team:
         model=model,
         tools=tools,
         members=[
-            # get_agent("index", "General", get_agent_params()),
+            get_agent("index", "General", get_agent_params()),
             get_agent("install", "Installation", get_agent_params()),
             get_agent("integrate", "Integration", get_agent_params()),
             get_agent("versions", "Versions", get_agent_params()),
@@ -65,7 +65,7 @@ def get_mitigator_team(user_id: str, session_id: str, model: Model) -> Team:
             get_agent("contact", "Support", get_agent_params()),
             get_agent("price", "Price", get_agent_params()),
             get_search_agent("web_search", "Web Search", get_agent_params()),
-            get_image_agent("image_gen", "Images", get_agent_params()),
+            # get_image_agent("image_gen", "Images", get_agent_params()),
         ],
         storage=get_storage("lead"),
         memory=get_team_memory(


### PR DESCRIPTION
This pull request includes several changes to the `massist` module, primarily focusing on cleaning up unused code and modifying agent parameters. The most important changes are as follows:

Code cleanup and removal of unused imports:

* Removed a default comment in the `get_agent` function in `massist/agent.py`.
* Removed an unused import for `get_image_agent` in `massist/team.py`.

Modification of agent parameters:

* Uncommented the `get_agent` call for the "index" agent in the `get_agent_params` function in `massist/team.py`.
* Commented out the `get_image_agent` call for the "image_gen" agent in the `get_agent_params` function in `massist/team.py`.- Removed unused `get_image_agent` import from `team.py`
- Uncommented the `get_agent` call in `get_mitigator_team` function to enable its functionality
- Cleaned up comments and fixed a FIXME note in `agent.py`